### PR TITLE
トレイアイコン表示修正・コンソールウィンドウ非表示化

### DIFF
--- a/src/Hotlaunch/Program.cs
+++ b/src/Hotlaunch/Program.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Windows;
 using Serilog;
 using Serilog.Events;
@@ -8,17 +7,9 @@ namespace Hotlaunch;
 
 static class Program
 {
-    [DllImport("kernel32.dll")]
-    private static extern bool AllocConsole();
-
     [STAThread]
     static void Main(string[] args)
     {
-        AllocConsole();
-        // コンソールウィンドウにフォーカスがある状態で Ctrl+C が届いても
-        // hotlaunch が終了しないようにする（モディファイアリマップの Ctrl 注入対策）
-        Console.CancelKeyPress += (_, e) => e.Cancel = true;
-
         // --verbose / -v で全キー押下ログを出す。デフォルトは INF のみ。
         bool verbose = args.Contains("--verbose") || args.Contains("-v");
         var minLevel = verbose ? LogEventLevel.Debug : LogEventLevel.Information;
@@ -29,7 +20,6 @@ static class Program
 
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Is(minLevel)
-            .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
             .WriteTo.File(logPath,
                 outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
                 rollingInterval: RollingInterval.Day,

--- a/src/Hotlaunch/TrayApp.cs
+++ b/src/Hotlaunch/TrayApp.cs
@@ -36,6 +36,7 @@ sealed class TrayApp : IDisposable
             ToolTipText = "hotlaunch",
             ContextMenu = contextMenu,
         };
+        _trayIcon.ForceCreate();
 
         // H.NotifyIcon は Icon を差し替えるたびに古い Icon を Dispose() する。
         // キャッシュすると 2 回目以降に ObjectDisposedException が発生するため、毎回新規生成する。


### PR DESCRIPTION
Closes #7

## 変更概要
- `TaskbarIcon.ForceCreate()` を追加 → WPF コードから生成した場合に必要
- 不要な `AllocConsole` / `ShowWindow` / `GetConsoleWindow` を削除