### PR TITLE
IPC経由でSpotify操作コマンド送受信を追加

### DIFF
--- a/src/Hotlaunch/IpcClient.cs
+++ b/src/Hotlaunch/IpcClient.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.IO.Pipes;
+
+namespace Hotlaunch;
+
+/// <summary>
+/// 常駐している hotlaunch プロセスへコマンドを送信するクライアント。
+/// </summary>
+static class IpcClient
+{
+    public static bool TrySend(string command)
+    {
+        try
+        {
+            using var pipe = new NamedPipeClientStream(".", IpcServer.PipeName, PipeDirection.Out);
+            pipe.Connect(1000);
+            using var writer = new StreamWriter(pipe);
+            writer.WriteLine(command);
+            writer.Flush();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/Hotlaunch/IpcServer.cs
+++ b/src/Hotlaunch/IpcServer.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using System.IO.Pipes;
+using Serilog;
+
+namespace Hotlaunch;
+
+/// <summary>
+/// 名前付きパイプ経由で他プロセスからのコマンドを受け付けるサーバー。
+/// </summary>
+sealed class IpcServer : IDisposable
+{
+    public const string PipeName = "hotlaunch-ipc";
+
+    public event Action<string>? CommandReceived;
+
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _task;
+
+    public IpcServer()
+    {
+        _task = Task.Run(RunAsync);
+    }
+
+    private async Task RunAsync()
+    {
+        while (!_cts.IsCancellationRequested)
+        {
+            try
+            {
+                using var pipe = new NamedPipeServerStream(
+                    PipeName, PipeDirection.In,
+                    NamedPipeServerStream.MaxAllowedServerInstances,
+                    PipeTransmissionMode.Byte,
+                    PipeOptions.Asynchronous);
+
+                await pipe.WaitForConnectionAsync(_cts.Token);
+
+                using var reader = new StreamReader(pipe);
+                var line = await reader.ReadLineAsync(_cts.Token);
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    Log.Information("IPC コマンド受信: {Command}", line);
+                    CommandReceived?.Invoke(line.Trim());
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "IPC サーバーエラー");
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+    }
+}

--- a/src/Hotlaunch/Program.cs
+++ b/src/Hotlaunch/Program.cs
@@ -10,6 +10,13 @@ static class Program
     [STAThread]
     static void Main(string[] args)
     {
+        // クライアントモード: 常駐インスタンスにコマンドを送って即終了
+        if (args.Contains("--spotify"))
+        {
+            IpcClient.TrySend("spotify-play-pause");
+            return;
+        }
+
         // --verbose / -v で全キー押下ログを出す。デフォルトは INF のみ。
         bool verbose = args.Contains("--verbose") || args.Contains("-v");
         // --tail でリアルタイムログウィンドウを表示する。

--- a/src/Hotlaunch/TrayApp.cs
+++ b/src/Hotlaunch/TrayApp.cs
@@ -19,6 +19,7 @@ sealed class TrayApp : IDisposable
     private readonly TaskbarIcon _trayIcon;
     private readonly KeyboardHook _hook;
     private readonly LeaderSequenceTracker _tracker;
+    private readonly IpcServer _ipcServer;
 
     public TrayApp()
     {
@@ -45,6 +46,14 @@ sealed class TrayApp : IDisposable
         // キャッシュすると 2 回目以降に ObjectDisposedException が発生するため、毎回新規生成する。
         _tracker.LeaderActivated   += () => _trayIcon.Dispatcher.Invoke(() => _trayIcon.Icon = CreateDotIcon(ActiveColor));
         _tracker.LeaderDeactivated += () => _trayIcon.Dispatcher.Invoke(() => _trayIcon.Icon = CreateDotIcon(NormalColor));
+
+        var spotifyHandler = new SpotifyPostActionHandler();
+        _ipcServer = new IpcServer();
+        _ipcServer.CommandReceived += cmd =>
+        {
+            if (spotifyHandler.CanHandle(cmd))
+                spotifyHandler.Execute(cmd, isNewlyLaunched: false);
+        };
     }
 
     private static Icon CreateDotIcon(Color color)
@@ -63,6 +72,7 @@ sealed class TrayApp : IDisposable
 
     public void Dispose()
     {
+        _ipcServer.Dispose();
         _hook.Dispose();
         _tracker.Dispose();
         _trayIcon.Dispose(); // 現在の Icon も H.NotifyIcon が Dispose する


### PR DESCRIPTION
Closes #17


## 変更内容

名前付きパイプを使った IPC（プロセス間通信）機能を追加し、`--spotify` フラグで常駐インスタンスへコマンドを送信できるようにした。

- **`IpcServer.cs`**: 名前付きパイプサーバーを新規追加。常駐プロセスがコマンドを待ち受け、受信時に `CommandReceived` イベントを発火する
- **`IpcClient.cs`**: 名前付きパイプクライアントを新規追加。常駐インスタンスへコマンドを送信して即終了する
- **`Program.cs`**: `--spotify` 引数で `IpcClient.TrySend("spotify-play-pause")` を呼び出してクライアントモードで起動するよう変更
- **`TrayApp.cs`**: `IpcServer` を保持し、`spotify-play-pause` コマンド受信時に `SpotifyPostActionHandler` で処理するよう接続。`Dispose()` に `_ipcServer.Dispose()` を追加

## テスト方法

1. 通常起動（常駐モード）で `hotlaunch.exe` を起動する
2. 別プロセスから `hotlaunch.exe --spotify` を実行する
3. Spotify の再生/一時停止が切り替わることを確認する
4. ログに `IPC コマンド受信: spotify-play-pause` が出力されていることを確認する
5. `hotlaunch.exe` が起動していない状態で `--spotify` を実行し、クラッシュせず即終了することを確認する（`TrySend` が `false` を返す）