### PR TITLE
チャードリーダーモード実装・リマッパー改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ obj/
 # OS
 .DS_Store
 Thumbs.db
+publish/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,13 +17,41 @@ System.UnauthorizedAccessException
 dotnet publish src/Hotlaunch/Hotlaunch.csproj \
   -r win-x64 -c Release --self-contained true -p:PublishSingleFile=true \
   -o /tmp/hotlaunch-publish && \
-cp /tmp/hotlaunch-publish/hotlaunch.exe /mnt/c/tools/hotlaunch/hotlaunch_new.exe && \
-cp /tmp/hotlaunch-publish/*.dll /mnt/c/tools/hotlaunch/
+cp /tmp/hotlaunch-publish/hotlaunch.exe /mnt/c/Prog/hotlaunch/hotlaunch_new.exe && \
+cp /tmp/hotlaunch-publish/*.dll /mnt/c/Prog/hotlaunch/
 ```
 
-出力先: `C:\tools\hotlaunch\hotlaunch_new.exe`
+出力先: `C:\Prog\hotlaunch\hotlaunch_new.exe`
 （既存の `hotlaunch.exe` を差し替える場合は kill してからリネーム）
 
 > **注意**: WPF のネイティブ DLL（`PresentationNative_cor3.dll`, `wpfgfx_cor3.dll` など）は
 > SingleFile に同梱されず、exe と同じディレクトリに置く必要がある。`*.dll` のコピーを忘れると
 > `DllNotFoundException` でクラッシュする。
+
+---
+
+## アーキテクチャ上の注意点
+
+### LeaderSequenceTracker の状態遷移
+
+`LeaderActivated` / `LeaderDeactivated` イベント（トレイアイコンの色変化）は **`WaitingForSequence` との境界でのみ発火する**。`PressingLeader` や `HoldingModifier` は中間状態なので発火しない。これを `TransitionTo` の外で勝手に呼ばないこと。
+
+### チャードリーダーモード（無変換+Space など）
+
+`LeaderConfig.ChordKey` を指定するとコードリーダーになる。状態遷移：
+
+```
+Idle → HoldingModifier（修飾キー押下）→ WaitingForSequence（チャードキー押下）→ Idle
+```
+
+- **HoldingModifier 中に修飾キーが単独解放**された場合（ソロタップ）：`OnKeyUp` は `Inject=[leaderVk↓, leaderVk↑]` を返してシステムに素通しする。こうしないと IME キーが効かなくなる。
+- **HoldingModifier 中にチャード以外のキーが押された**場合：`InjectForRemapper=[leaderVk↓, comboKey↓]` を返してリマッパー経由で再注入する（Ctrl+C 等が維持される）。
+- `KeyboardHook` の `[2c]` セクションで `_tracker.OnKeyUp()` の**戻り値を使うこと**。無視すると Inject が送られず IME キーが詰まる。
+
+### NonComboKeys（IME キー）
+
+`ModifierRemapper.NonComboKeys` = `{0x1C 変換, 0x1D 無変換, 0x15 カナ}`。これらはリマッパーのコンボ対象外。`DispatchInjectForRemapper` はリストの末尾キーで `IsComboTarget` を確認し、IME キーなら `SendKeys`（素通し）、通常キーなら `SendKeysForRemapper`（Ctrl 等にマップ）に振り分ける。
+
+### リーダーキーと ModifierRemapper の競合
+
+リーダーキーが ModifierRemapper のソースキーでもある場合（例: 無変換→Ctrl のリマップ ＋ 無変換 をリーダーとして使用）、リマッパーがリーダーキーを横取りしてしまう。`HookCallback` の `[2]` セクションでリーダーキーをトラッカーが先に処理し、ブロック時は `SuppressNextKeyUp` でキーアップの誤注入を防ぐ。

--- a/src/Hotlaunch.Core/Config/HotkeyConfig.cs
+++ b/src/Hotlaunch.Core/Config/HotkeyConfig.cs
@@ -7,6 +7,11 @@ public class LeaderConfig
     public int Count { get; set; } = 1;
     /// <summary>null = single/double-press モード。キー名を指定すると Key+ChordKey のコードリーダーになる。</summary>
     public string? ChordKey { get; set; } = null;
+    /// <summary>
+    /// チャードリーダーモード時に、修飾キー押下からチャードキー押下までの最低待機時間（ms）。
+    /// これより短い同時押しは親指シフト等の通常入力として素通しする。デフォルト 200ms。
+    /// </summary>
+    public int ChordDelayMs { get; set; } = 200;
 }
 
 public class HotkeyEntry

--- a/src/Hotlaunch.Core/Config/HotkeyConfig.cs
+++ b/src/Hotlaunch.Core/Config/HotkeyConfig.cs
@@ -5,6 +5,8 @@ public class LeaderConfig
     public string Key { get; set; } = "Alt";
     public int TimeoutMs { get; set; } = 2000;
     public int Count { get; set; } = 1;
+    /// <summary>null = single/double-press モード。キー名を指定すると Key+ChordKey のコードリーダーになる。</summary>
+    public string? ChordKey { get; set; } = null;
 }
 
 public class HotkeyEntry

--- a/src/Hotlaunch.Core/LeaderSequenceTracker.cs
+++ b/src/Hotlaunch.Core/LeaderSequenceTracker.cs
@@ -12,9 +12,11 @@ public sealed class LeaderSequenceTracker : IDisposable
     private int _pressCount;
     private System.Threading.Timer? _timer;
     private readonly int _leaderVk;
-    private readonly int _chordVk; // -1 = single/double-press モード
+    private readonly int _chordVk;       // -1 = single/double-press モード
     private readonly int _timeoutMs;
+    private readonly int _chordDelayMs;  // この時間より短い同時押しは素通し
     private readonly int _leaderPressesNeeded;
+    private long _holdingModifierStartMs;
     private readonly IReadOnlyDictionary<int, HotkeyEntry> _sequences;
 
     public event Action<HotkeyEntry>? SequenceMatched;
@@ -27,11 +29,12 @@ public sealed class LeaderSequenceTracker : IDisposable
     public int LeaderVk => _leaderVk;
     public int ChordVk  => _chordVk;
 
-    public LeaderSequenceTracker(int leaderVk, int timeoutMs, IEnumerable<(int Vk, HotkeyEntry Entry)> sequences, int leaderCount = 1, int chordVk = -1)
+    public LeaderSequenceTracker(int leaderVk, int timeoutMs, IEnumerable<(int Vk, HotkeyEntry Entry)> sequences, int leaderCount = 1, int chordVk = -1, int chordDelayMs = 200)
     {
         _leaderVk = leaderVk;
         _chordVk  = chordVk;
         _timeoutMs = timeoutMs;
+        _chordDelayMs = chordDelayMs;
         _leaderPressesNeeded = Math.Max(1, leaderCount);
         _sequences = sequences.ToDictionary(x => x.Vk, x => x.Entry);
     }
@@ -71,7 +74,11 @@ public sealed class LeaderSequenceTracker : IDisposable
         // Idle/HoldingModifier + リーダーキー → HoldingModifier
         if ((_state == State.Idle || _state == State.HoldingModifier) && vkCode == _leaderVk)
         {
-            if (_state == State.Idle) TransitionTo(State.HoldingModifier);
+            if (_state == State.Idle)
+            {
+                TransitionTo(State.HoldingModifier);
+                _holdingModifierStartMs = Environment.TickCount64;
+            }
             ResetTimer();
             Log.Information("チャードリーダー修飾キー押下 → 修飾待機");
             return new RemapResult(true, []);
@@ -82,13 +89,22 @@ public sealed class LeaderSequenceTracker : IDisposable
             if (ModifierVkCodes.Contains(vkCode))
                 return new RemapResult(false, []);
 
-            // チャードキー → WaitingForSequence
+            // チャードキー → 保持時間が ChordDelayMs 未満なら同時押し扱いで素通し
             if (vkCode == _chordVk)
             {
+                var elapsed = Environment.TickCount64 - _holdingModifierStartMs;
+                if (elapsed < _chordDelayMs)
+                {
+                    // 親指シフト等の同時押し → キャンセルして両キーを素通し注入（リマッパー不使用）
+                    CancelTimer();
+                    TransitionTo(State.Idle);
+                    Log.Debug("チャードキー同時押し検出 ({Elapsed}ms < {Delay}ms) → 素通し再注入", elapsed, _chordDelayMs);
+                    return new RemapResult(true, [(_leaderVk, false), (vkCode, false)]);
+                }
                 CancelTimer();
                 TransitionTo(State.WaitingForSequence);
                 ResetTimer();
-                Log.Information("チャードキー押下 → 待機モード開始 ({TimeoutMs}ms)", _timeoutMs);
+                Log.Information("チャードキー押下 ({Elapsed}ms) → 待機モード開始 ({TimeoutMs}ms)", elapsed, _timeoutMs);
                 return new RemapResult(true, []);
             }
 
@@ -175,21 +191,22 @@ public sealed class LeaderSequenceTracker : IDisposable
             return new RemapResult(true, [(_leaderVk, false), (vkCode, false)]);
     }
 
-    /// <summary>キー解放を通知する。コードモードでリーダー修飾キーが解放された場合に状態を戻す。</summary>
-    public RemapResult OnKeyUp(int vkCode)
+    /// <summary>
+    /// キー解放を通知する。チャードモードでリーダー修飾キーが解放された場合に状態を Idle へ戻す。
+    /// ソロタップ再注入等の処理は KeyboardHook 側で IsSourceKey に基づいて行う。
+    /// </summary>
+    public bool OnKeyUp(int vkCode)
     {
         lock (_lock)
         {
-            // コードモード: HoldingModifier 中にリーダー修飾キーが解放 → Idle へ
-            // ソロタップ扱いで元キーを再注入（IME キーとして機能させる）
             if (_chordVk >= 0 && _state == State.HoldingModifier && vkCode == _leaderVk)
             {
                 CancelTimer();
                 TransitionTo(State.Idle);
-                Log.Debug("チャードリーダー修飾キー単独解放 → Idle + ソロタップ再注入");
-                return new RemapResult(true, [(_leaderVk, false), (_leaderVk, true)]);
+                Log.Debug("チャードリーダー修飾キー単独解放 → Idle");
+                return true; // キー解放を検出したことをフックに通知
             }
-            return new RemapResult(false, []);
+            return false;
         }
     }
 

--- a/src/Hotlaunch.Core/LeaderSequenceTracker.cs
+++ b/src/Hotlaunch.Core/LeaderSequenceTracker.cs
@@ -5,13 +5,14 @@ namespace Hotlaunch.Core;
 
 public sealed class LeaderSequenceTracker : IDisposable
 {
-    private enum State { Idle, PressingLeader, WaitingForSequence }
+    private enum State { Idle, PressingLeader, HoldingModifier, WaitingForSequence }
 
     private readonly object _lock = new();
     private State _state = State.Idle;
     private int _pressCount;
     private System.Threading.Timer? _timer;
     private readonly int _leaderVk;
+    private readonly int _chordVk; // -1 = single/double-press モード
     private readonly int _timeoutMs;
     private readonly int _leaderPressesNeeded;
     private readonly IReadOnlyDictionary<int, HotkeyEntry> _sequences;
@@ -20,9 +21,16 @@ public sealed class LeaderSequenceTracker : IDisposable
     public event Action? LeaderActivated;
     public event Action? LeaderDeactivated;
 
-    public LeaderSequenceTracker(int leaderVk, int timeoutMs, IEnumerable<(int Vk, HotkeyEntry Entry)> sequences, int leaderCount = 1)
+    public bool IsWaitingForSequence { get { lock (_lock) { return _state == State.WaitingForSequence; } } }
+    public bool IsHoldingModifier   { get { lock (_lock) { return _state == State.HoldingModifier; } } }
+    public bool IsSequenceKey(int vk) => _sequences.ContainsKey(vk);
+    public int LeaderVk => _leaderVk;
+    public int ChordVk  => _chordVk;
+
+    public LeaderSequenceTracker(int leaderVk, int timeoutMs, IEnumerable<(int Vk, HotkeyEntry Entry)> sequences, int leaderCount = 1, int chordVk = -1)
     {
         _leaderVk = leaderVk;
+        _chordVk  = chordVk;
         _timeoutMs = timeoutMs;
         _leaderPressesNeeded = Math.Max(1, leaderCount);
         _sequences = sequences.ToDictionary(x => x.Vk, x => x.Entry);
@@ -37,75 +45,165 @@ public sealed class LeaderSequenceTracker : IDisposable
         0x5B, 0x5C,        // LWin, RWin
     ];
 
-    /// <summary>キー押下を通知する。true を返した場合はそのキーを抑制する。</summary>
-    public bool OnKeyDown(int vkCode)
+    /// <summary>キー押下を通知する。Block=true の場合はそのキーを抑制する。</summary>
+    public RemapResult OnKeyDown(int vkCode)
     {
         lock (_lock)
         {
-            if ((_state == State.Idle || _state == State.PressingLeader) && vkCode == _leaderVk)
-            {
-                _pressCount = _state == State.PressingLeader ? _pressCount + 1 : 1;
+            if (_chordVk >= 0)
+                return OnKeyDownChord(vkCode);
+            else
+                return OnKeyDownSingle(vkCode);
+        }
+    }
 
-                if (_pressCount >= _leaderPressesNeeded)
-                {
-                    TransitionTo(State.WaitingForSequence);
-                    Log.Information("リーダーキー {Count}回押下 → 待機モード開始 ({TimeoutMs}ms)", _pressCount, _timeoutMs);
-                }
-                else
-                {
-                    TransitionTo(State.PressingLeader);
-                    Log.Information("リーダーキー {Count}/{Needed}回押下 → 連打待機", _pressCount, _leaderPressesNeeded);
-                }
+    // コードモード（無変換+Space など）
+    private RemapResult OnKeyDownChord(int vkCode)
+    {
+        // WaitingForSequence 中にリーダー or チャードキーが再押し → タイマーリフレッシュ
+        if (_state == State.WaitingForSequence && (vkCode == _leaderVk || vkCode == _chordVk))
+        {
+            ResetTimer();
+            Log.Information("チャードリーダー再押下 (WaitingForSequence) → タイマーリフレッシュ");
+            return new RemapResult(true, []);
+        }
+
+        // Idle/HoldingModifier + リーダーキー → HoldingModifier
+        if ((_state == State.Idle || _state == State.HoldingModifier) && vkCode == _leaderVk)
+        {
+            if (_state == State.Idle) TransitionTo(State.HoldingModifier);
+            ResetTimer();
+            Log.Information("チャードリーダー修飾キー押下 → 修飾待機");
+            return new RemapResult(true, []);
+        }
+
+        if (_state == State.HoldingModifier)
+        {
+            if (ModifierVkCodes.Contains(vkCode))
+                return new RemapResult(false, []);
+
+            // チャードキー → WaitingForSequence
+            if (vkCode == _chordVk)
+            {
+                CancelTimer();
+                TransitionTo(State.WaitingForSequence);
                 ResetTimer();
-                return true;
+                Log.Information("チャードキー押下 → 待機モード開始 ({TimeoutMs}ms)", _timeoutMs);
+                return new RemapResult(true, []);
             }
 
-            if (_state == State.PressingLeader)
-            {
-                // リーダー以外のModifierキーは無視して連打待機継続
-                if (ModifierVkCodes.Contains(vkCode))
-                    return false;
+            // チャード以外のキー → キャンセル。飲み込んだリーダーをリマッパー経由で再注入（Ctrl+key 維持）
+            CancelTimer();
+            TransitionTo(State.Idle);
+            Log.Debug("チャードキャンセル（VkCode={VkCode}）→ Idle + リーダー+キーをリマッパー経由で再注入", vkCode);
+            return new RemapResult(true, [], [(_leaderVk, false), (vkCode, false)]);
+        }
 
-                // 非修飾キー → キャンセル
+        return OnKeyDownWaiting(vkCode);
+    }
+
+    // シングル/ダブルプレスモード
+    private RemapResult OnKeyDownSingle(int vkCode)
+    {
+        // WaitingForSequence 中にリーダーキーが再押し → タイマーリフレッシュ
+        if (_state == State.WaitingForSequence && vkCode == _leaderVk)
+        {
+            ResetTimer();
+            Log.Information("リーダーキー再押下 (WaitingForSequence) → タイマーリフレッシュ");
+            return new RemapResult(true, []);
+        }
+
+        if ((_state == State.Idle || _state == State.PressingLeader) && vkCode == _leaderVk)
+        {
+            _pressCount = _state == State.PressingLeader ? _pressCount + 1 : 1;
+            if (_pressCount >= _leaderPressesNeeded)
+            {
+                TransitionTo(State.WaitingForSequence);
+                Log.Information("リーダーキー {Count}回押下 → 待機モード開始 ({TimeoutMs}ms)", _pressCount, _timeoutMs);
+            }
+            else
+            {
+                TransitionTo(State.PressingLeader);
+                Log.Information("リーダーキー {Count}/{Needed}回押下 → 連打待機", _pressCount, _leaderPressesNeeded);
+            }
+            ResetTimer();
+            return new RemapResult(true, []);
+        }
+
+        if (_state == State.PressingLeader)
+        {
+            if (ModifierVkCodes.Contains(vkCode))
+                return new RemapResult(false, []);
+
+            var injectForRemapper = new List<(int, bool)>();
+            for (int i = 0; i < _pressCount; i++)
+                injectForRemapper.Add((_leaderVk, false));
+            injectForRemapper.Add((vkCode, false));
+            CancelTimer();
+            TransitionTo(State.Idle);
+            Log.Debug("連打キャンセル（VkCode={VkCode}）→ Idle + リーダー×{Count}+キーをリマッパー経由で再注入", vkCode, _pressCount);
+            return new RemapResult(true, [], injectForRemapper);
+        }
+
+        return OnKeyDownWaiting(vkCode);
+    }
+
+    // WaitingForSequence 共通処理
+    private RemapResult OnKeyDownWaiting(int vkCode)
+    {
+        if (_state != State.WaitingForSequence)
+            return new RemapResult(false, []);
+
+        if (ModifierVkCodes.Contains(vkCode))
+            return new RemapResult(false, []);
+
+        CancelTimer();
+        TransitionTo(State.Idle);
+
+        if (_sequences.TryGetValue(vkCode, out var entry))
+        {
+            Log.Information("シーケンスキー {VkCode} → マッチ ({AppPath})", vkCode, entry.AppPath);
+            SequenceMatched?.Invoke(entry);
+            return new RemapResult(true, []);
+        }
+
+        // 未登録キー → 飲み込んだキーを再注入（親指シフト等の組み合わせを壊さない）
+        Log.Debug("シーケンスキー {VkCode} → 未登録、リーダー+キー再注入", vkCode);
+        if (_chordVk >= 0)
+            return new RemapResult(true, [(_leaderVk, false), (_chordVk, false), (vkCode, false)]);
+        else
+            return new RemapResult(true, [(_leaderVk, false), (vkCode, false)]);
+    }
+
+    /// <summary>キー解放を通知する。コードモードでリーダー修飾キーが解放された場合に状態を戻す。</summary>
+    public RemapResult OnKeyUp(int vkCode)
+    {
+        lock (_lock)
+        {
+            // コードモード: HoldingModifier 中にリーダー修飾キーが解放 → Idle へ
+            // ソロタップ扱いで元キーを再注入（IME キーとして機能させる）
+            if (_chordVk >= 0 && _state == State.HoldingModifier && vkCode == _leaderVk)
+            {
                 CancelTimer();
                 TransitionTo(State.Idle);
-                Log.Debug("連打キャンセル（VkCode={VkCode}）→ Idle", vkCode);
-                return false;
+                Log.Debug("チャードリーダー修飾キー単独解放 → Idle + ソロタップ再注入");
+                return new RemapResult(true, [(_leaderVk, false), (_leaderVk, true)]);
             }
-
-            if (_state == State.WaitingForSequence)
-            {
-                // Modifier キーは無視して待機継続
-                if (ModifierVkCodes.Contains(vkCode))
-                    return false;
-
-                CancelTimer();
-                TransitionTo(State.Idle);
-
-                if (_sequences.TryGetValue(vkCode, out var entry))
-                {
-                    Log.Information("シーケンスキー {VkCode} → マッチ ({AppPath})", vkCode, entry.AppPath);
-                    SequenceMatched?.Invoke(entry);
-                    return true;
-                }
-
-                Log.Debug("シーケンスキー {VkCode} → 未登録、スルー", vkCode);
-                return false;
-            }
-
-            return false;
+            return new RemapResult(false, []);
         }
     }
 
     private void TransitionTo(State newState)
     {
-        bool wasIdle = _state == State.Idle;
+        // LeaderActivated/Deactivated は WaitingForSequence との境界でのみ発火する。
+        // HoldingModifier や PressingLeader は中間状態のためアイコンを変えない。
+        bool wasWaiting = _state == State.WaitingForSequence;
         _state = newState;
-        bool isNowIdle = _state == State.Idle;
+        bool isNowWaiting = _state == State.WaitingForSequence;
 
-        if (wasIdle && !isNowIdle)
+        if (!wasWaiting && isNowWaiting)
             LeaderActivated?.Invoke();
-        else if (!wasIdle && isNowIdle)
+        else if (wasWaiting && !isNowWaiting)
             LeaderDeactivated?.Invoke();
     }
 
@@ -116,7 +214,7 @@ public sealed class LeaderSequenceTracker : IDisposable
         {
             lock (_lock)
             {
-                if (_state == State.PressingLeader || _state == State.WaitingForSequence)
+                if (_state == State.PressingLeader || _state == State.HoldingModifier || _state == State.WaitingForSequence)
                 {
                     Log.Debug("タイムアウト → 待機モード解除");
                     TransitionTo(State.Idle);

--- a/src/Hotlaunch.Core/ModifierRemapper.cs
+++ b/src/Hotlaunch.Core/ModifierRemapper.cs
@@ -2,7 +2,15 @@ using Serilog;
 
 namespace Hotlaunch.Core;
 
-public readonly record struct RemapResult(bool Block, IReadOnlyList<(int Vk, bool KeyUp)> Inject);
+public readonly record struct RemapResult(
+    bool Block,
+    IReadOnlyList<(int Vk, bool KeyUp)> Inject,
+    IReadOnlyList<(int Vk, bool KeyUp)> InjectForRemapper)
+{
+    // 後方互換: Inject のみ指定する 2 引数コンストラクタ
+    public RemapResult(bool block, IReadOnlyList<(int Vk, bool KeyUp)> inject)
+        : this(block, inject, []) { }
+}
 
 public sealed class ModifierRemapper
 {
@@ -10,9 +18,22 @@ public sealed class ModifierRemapper
     private readonly HashSet<int> _heldSources = new();
     private readonly HashSet<int> _usedAsModifier = new();
     private readonly HashSet<int> _heldNonSourceKeys = new();
+    // Reset() 時に保留中だったソースキー。UP イベントをスルーして誤ったソロタップ注入を防ぐ
+    private readonly HashSet<int> _ghostSources = new();
+
+    // これらの IME キーはコンボ対象外（Ctrl+変換 等を意図せず生成しない）
+    private static readonly HashSet<int> NonComboKeys =
+    [
+        0x1C, // VK_CONVERT（変換）
+        0x1D, // VK_NONCONVERT（無変換）
+        0x15, // VK_KANA
+    ];
 
     public ModifierRemapper(IEnumerable<(int sourceVk, int targetVk)> rules)
         => _rules = rules.ToDictionary(r => r.sourceVk, r => r.targetVk);
+
+    /// <summary>このキーがソースキー保持中にコンボ対象になるかどうか。</summary>
+    public bool IsComboTarget(int vk) => !NonComboKeys.Contains(vk);
 
     public bool HasPendingState =>
         _heldSources.Count > 0 || _heldNonSourceKeys.Count > 0;
@@ -22,9 +43,17 @@ public sealed class ModifierRemapper
         $"usedAsModifier=[{string.Join(",", _usedAsModifier.Select(v => $"0x{v:X2}"))}] " +
         $"heldNonSourceKeys=[{string.Join(",", _heldNonSourceKeys.Select(v => $"0x{v:X2}"))}]";
 
+    /// <summary>
+    /// 次回の指定キー UP をゴーストとして抑制する。
+    /// トラッカーがリーダーキーの DOWN をブロックしたとき、リマッパーが知らずにソロタップを
+    /// 注入しないよう呼ぶ。
+    /// </summary>
+    public void SuppressNextKeyUp(int vk) => _ghostSources.Add(vk);
+
     /// <summary>スタック状態をリセットする。無変換+C が効かなくなったときにトレイから呼ぶ。</summary>
     public void Reset()
     {
+        foreach (var s in _heldSources) _ghostSources.Add(s);
         _heldSources.Clear();
         _usedAsModifier.Clear();
         _heldNonSourceKeys.Clear();
@@ -40,9 +69,14 @@ public sealed class ModifierRemapper
             Log.Information("リマッパー: 0x{VkHex} 押下 → ソースキー追跡開始", vkCode.ToString("X2"));
             return new RemapResult(true, []);
         }
-        // ソースキー保持中 → ターゲット+元キーを注入
+        // ソースキー保持中 → ターゲット+元キーを注入（ただし IME キー等は非コンボ対象）
         if (_heldSources.Count > 0)
         {
+            if (NonComboKeys.Contains(vkCode))
+            {
+                Log.Debug("リマッパー: 0x{VkHex} はコンボ対象外 → 素通し", vkCode.ToString("X2"));
+                return new RemapResult(false, []);
+            }
             var inject = new List<(int, bool)>();
             foreach (var src in _heldSources)
                 if (_usedAsModifier.Add(src))
@@ -59,6 +93,13 @@ public sealed class ModifierRemapper
 
     public RemapResult OnKeyUp(int vkCode)
     {
+        // ゴーストソースキー → heldSources に再登録されていなければ抑制（ソロタップ注入を防ぐ）
+        if (_ghostSources.Remove(vkCode) && !_heldSources.Contains(vkCode))
+        {
+            Log.Debug("リマッパー: 0x{VkHex} ゴーストソースキーリリース → 無視", vkCode.ToString("X2"));
+            return new RemapResult(true, []);
+        }
+
         // ソースキーリリース
         if (_rules.TryGetValue(vkCode, out int targetVk))
         {

--- a/src/Hotlaunch.Core/ModifierRemapper.cs
+++ b/src/Hotlaunch.Core/ModifierRemapper.cs
@@ -21,12 +21,13 @@ public sealed class ModifierRemapper
     // Reset() 時に保留中だったソースキー。UP イベントをスルーして誤ったソロタップ注入を防ぐ
     private readonly HashSet<int> _ghostSources = new();
 
-    // これらの IME キーはコンボ対象外（Ctrl+変換 等を意図せず生成しない）
+    // これらのキーはコンボ対象外（Ctrl+変換/Space 等を意図せず生成しない）
     private static readonly HashSet<int> NonComboKeys =
     [
         0x1C, // VK_CONVERT（変換）
         0x1D, // VK_NONCONVERT（無変換）
         0x15, // VK_KANA
+        0x20, // VK_SPACE（親指シフトの右親指キーとして使う場合に変換しない）
     ];
 
     public ModifierRemapper(IEnumerable<(int sourceVk, int targetVk)> rules)
@@ -34,6 +35,9 @@ public sealed class ModifierRemapper
 
     /// <summary>このキーがソースキー保持中にコンボ対象になるかどうか。</summary>
     public bool IsComboTarget(int vk) => !NonComboKeys.Contains(vk);
+
+    /// <summary>このキーがリマッパーのソースキーかどうか（無変換等）。</summary>
+    public bool IsSourceKey(int vk) => _rules.ContainsKey(vk);
 
     public bool HasPendingState =>
         _heldSources.Count > 0 || _heldNonSourceKeys.Count > 0;
@@ -62,12 +66,12 @@ public sealed class ModifierRemapper
 
     public RemapResult OnKeyDown(int vkCode)
     {
-        // ソースキー押下 → 追跡開始
+        // ソースキー押下 → 追跡開始（物理キーは素通し: 親指シフト等がそのまま受け取れる）
         if (_rules.ContainsKey(vkCode))
         {
             _heldSources.Add(vkCode);
-            Log.Information("リマッパー: 0x{VkHex} 押下 → ソースキー追跡開始", vkCode.ToString("X2"));
-            return new RemapResult(true, []);
+            Log.Information("リマッパー: 0x{VkHex} 押下 → ソースキー追跡開始 (素通し)", vkCode.ToString("X2"));
+            return new RemapResult(false, []);
         }
         // ソースキー保持中 → ターゲット+元キーを注入（ただし IME キー等は非コンボ対象）
         if (_heldSources.Count > 0)
@@ -107,14 +111,15 @@ public sealed class ModifierRemapper
             bool wasUsed = _usedAsModifier.Remove(vkCode);
             if (wasUsed)
             {
-                Log.Information("リマッパー: 0x{VkHex} リリース (修飾キーとして使用済み → 0x{TargetHex}↑注入)",
+                Log.Information("リマッパー: 0x{VkHex} リリース (修飾キーとして使用済み → 0x{TargetHex}↑注入, 物理↑素通し)",
                     vkCode.ToString("X2"), targetVk.ToString("X2"));
-                return new RemapResult(true, [(targetVk, true)]);
+                return new RemapResult(false, [(targetVk, true)]);
             }
             else
             {
-                Log.Information("リマッパー: 0x{VkHex} リリース (単独押し → 元キー注入)", vkCode.ToString("X2"));
-                return new RemapResult(true, [(vkCode, false), (vkCode, true)]);
+                // 単独押し: 物理キーは OnKeyDown 時に素通し済みなので物理↑もそのまま通す
+                Log.Information("リマッパー: 0x{VkHex} リリース (単独押し → 素通し)", vkCode.ToString("X2"));
+                return new RemapResult(false, []);
             }
         }
         // コンボ中に押された非ソースキーのリリース → キーアップを注入（ソース先行リリース時も対応）

--- a/src/Hotlaunch.Tests/LeaderSequenceTrackerTests.cs
+++ b/src/Hotlaunch.Tests/LeaderSequenceTrackerTests.cs
@@ -165,10 +165,11 @@ public class LeaderSequenceTrackerTests
     private const int SpaceVk    = 0x20;
     private const int MuhenkanVk = 0x1D;
 
-    private static LeaderSequenceTracker CreateChordTracker(int timeoutMs = 2000)
+    // テストは瞬時実行なので chordDelayMs=0 をデフォルトにする
+    private static LeaderSequenceTracker CreateChordTracker(int timeoutMs = 2000, int chordDelayMs = 0)
     {
         var entry = new HotkeyEntry { Key = "W", AppPath = @"C:\wezterm-gui.exe", ProcessName = "wezterm-gui" };
-        return new LeaderSequenceTracker(MuhenkanVk, timeoutMs, [(WVk, entry)], chordVk: SpaceVk);
+        return new LeaderSequenceTracker(MuhenkanVk, timeoutMs, [(WVk, entry)], chordVk: SpaceVk, chordDelayMs: chordDelayMs);
     }
 
     [Fact]
@@ -188,6 +189,27 @@ public class LeaderSequenceTrackerTests
         var result = tracker.OnKeyDown(SpaceVk);
         Assert.True(result.Block);
         Assert.True(tracker.IsWaitingForSequence);
+    }
+
+    [Fact]
+    public void チャード_同時押しはリマッパー経由で素通しする()
+    {
+        // ChordDelayMs=200 で、即座に Space を押した場合は親指シフト扱い
+        using var tracker = CreateChordTracker(chordDelayMs: 200);
+        HotkeyEntry? fired = null;
+        tracker.SequenceMatched += e => fired = e;
+
+        tracker.OnKeyDown(MuhenkanVk);
+        // すぐに Space → 同時押し扱い（経過時間ほぼ 0ms < 200ms）
+        var result = tracker.OnKeyDown(SpaceVk);
+
+        Assert.Null(fired);
+        Assert.True(result.Block);
+        Assert.False(tracker.IsWaitingForSequence);
+        // 両キーをリマッパーを通さず素通し注入（Ctrl+Space にならないよう）
+        Assert.Equal(2, result.Inject.Count);
+        Assert.Equal((MuhenkanVk, false), result.Inject[0]);
+        Assert.Equal((SpaceVk,    false), result.Inject[1]);
     }
 
     [Fact]
@@ -224,20 +246,17 @@ public class LeaderSequenceTrackerTests
     }
 
     [Fact]
-    public void チャード_無変換解放でHoldingModifierからIdleに戻りソロタップ再注入する()
+    public void チャード_無変換解放でHoldingModifierからIdleに戻る()
     {
         using var tracker = CreateChordTracker();
         tracker.OnKeyDown(MuhenkanVk);
         Assert.True(tracker.IsHoldingModifier);
 
-        var result = tracker.OnKeyUp(MuhenkanVk);
-        Assert.True(result.Block);
+        bool detected = tracker.OnKeyUp(MuhenkanVk);
+        Assert.True(detected); // リーダー解放を検出
         Assert.False(tracker.IsHoldingModifier);
         Assert.False(tracker.IsWaitingForSequence);
-        // ソロタップとして元キーを再注入する
-        Assert.Equal(2, result.Inject.Count);
-        Assert.Equal((MuhenkanVk, false), result.Inject[0]); // 無変換↓
-        Assert.Equal((MuhenkanVk, true),  result.Inject[1]); // 無変換↑
+        // ソロタップ再注入は KeyboardHook 側（IsSourceKey で判断）が担当
     }
 
     [Fact]

--- a/src/Hotlaunch.Tests/LeaderSequenceTrackerTests.cs
+++ b/src/Hotlaunch.Tests/LeaderSequenceTrackerTests.cs
@@ -20,7 +20,7 @@ public class LeaderSequenceTrackerTests
     public void Alt押下はキーを抑制する()
     {
         using var tracker = CreateTracker();
-        Assert.True(tracker.OnKeyDown(AltVk));
+        Assert.True(tracker.OnKeyDown(AltVk).Block);
     }
 
     [Fact]
@@ -31,24 +31,28 @@ public class LeaderSequenceTrackerTests
         tracker.SequenceMatched += e => fired = e;
 
         tracker.OnKeyDown(AltVk);
-        var suppressed = tracker.OnKeyDown(WVk);
+        var result = tracker.OnKeyDown(WVk);
 
         Assert.NotNull(fired);
-        Assert.True(suppressed);
+        Assert.True(result.Block);
     }
 
     [Fact]
-    public void Alt後に未登録キーはイベントを発火せず通過する()
+    public void Alt後に未登録キーはイベントを発火せずリーダーとキーを再注入する()
     {
         using var tracker = CreateTracker();
         HotkeyEntry? fired = null;
         tracker.SequenceMatched += e => fired = e;
 
         tracker.OnKeyDown(AltVk);
-        var suppressed = tracker.OnKeyDown(AVk);
+        var result = tracker.OnKeyDown(AVk);
 
         Assert.Null(fired);
-        Assert.False(suppressed);
+        // 元キーはブロックし、リーダー→元キーの順で再注入する
+        Assert.True(result.Block);
+        Assert.Equal(2, result.Inject.Count);
+        Assert.Equal((AltVk, false), result.Inject[0]);
+        Assert.Equal((AVk, false), result.Inject[1]);
     }
 
     [Fact]
@@ -103,9 +107,9 @@ public class LeaderSequenceTrackerTests
         tracker.OnKeyDown(AltVk);
 
         // Modifier キーを押しても待機解除されない
-        Assert.False(tracker.OnKeyDown(0xA0)); // Shift
-        Assert.False(tracker.OnKeyDown(0xA2)); // Ctrl
-        Assert.False(tracker.OnKeyDown(0x5B)); // Win
+        Assert.False(tracker.OnKeyDown(0xA0).Block); // Shift
+        Assert.False(tracker.OnKeyDown(0xA2).Block); // Ctrl
+        Assert.False(tracker.OnKeyDown(0x5B).Block); // Win
 
         // その後 W を押すとマッチする
         tracker.OnKeyDown(WVk);
@@ -154,5 +158,104 @@ public class LeaderSequenceTrackerTests
         tracker.OnKeyDown(WVk);   // タイムアウト前のW → マッチするはず
 
         Assert.NotNull(fired);
+    }
+
+    // ---- チャードリーダーモード (無変換+Space) のテスト ----
+
+    private const int SpaceVk    = 0x20;
+    private const int MuhenkanVk = 0x1D;
+
+    private static LeaderSequenceTracker CreateChordTracker(int timeoutMs = 2000)
+    {
+        var entry = new HotkeyEntry { Key = "W", AppPath = @"C:\wezterm-gui.exe", ProcessName = "wezterm-gui" };
+        return new LeaderSequenceTracker(MuhenkanVk, timeoutMs, [(WVk, entry)], chordVk: SpaceVk);
+    }
+
+    [Fact]
+    public void チャード_無変換押下はブロックしIsHoldingModifierになる()
+    {
+        using var tracker = CreateChordTracker();
+        var result = tracker.OnKeyDown(MuhenkanVk);
+        Assert.True(result.Block);
+        Assert.True(tracker.IsHoldingModifier);
+    }
+
+    [Fact]
+    public void チャード_無変換Space押下でWaitingForSequenceになる()
+    {
+        using var tracker = CreateChordTracker();
+        tracker.OnKeyDown(MuhenkanVk);
+        var result = tracker.OnKeyDown(SpaceVk);
+        Assert.True(result.Block);
+        Assert.True(tracker.IsWaitingForSequence);
+    }
+
+    [Fact]
+    public void チャード_無変換Space後にWでイベント発火する()
+    {
+        using var tracker = CreateChordTracker();
+        HotkeyEntry? fired = null;
+        tracker.SequenceMatched += e => fired = e;
+
+        tracker.OnKeyDown(MuhenkanVk);
+        tracker.OnKeyDown(SpaceVk);
+        var result = tracker.OnKeyDown(WVk);
+
+        Assert.NotNull(fired);
+        Assert.True(result.Block);
+    }
+
+    [Fact]
+    public void チャード_無変換後に別キーでキャンセルしリマッパー経由再注入する()
+    {
+        using var tracker = CreateChordTracker();
+        HotkeyEntry? fired = null;
+        tracker.SequenceMatched += e => fired = e;
+
+        tracker.OnKeyDown(MuhenkanVk);
+        var result = tracker.OnKeyDown(0x43); // C キー
+
+        Assert.Null(fired);
+        Assert.True(result.Block);
+        // 無変換+C をリマッパー経由で再注入（Ctrl+C になる）
+        Assert.Equal(2, result.InjectForRemapper.Count);
+        Assert.Equal((MuhenkanVk, false), result.InjectForRemapper[0]);
+        Assert.Equal((0x43, false), result.InjectForRemapper[1]);
+    }
+
+    [Fact]
+    public void チャード_無変換解放でHoldingModifierからIdleに戻りソロタップ再注入する()
+    {
+        using var tracker = CreateChordTracker();
+        tracker.OnKeyDown(MuhenkanVk);
+        Assert.True(tracker.IsHoldingModifier);
+
+        var result = tracker.OnKeyUp(MuhenkanVk);
+        Assert.True(result.Block);
+        Assert.False(tracker.IsHoldingModifier);
+        Assert.False(tracker.IsWaitingForSequence);
+        // ソロタップとして元キーを再注入する
+        Assert.Equal(2, result.Inject.Count);
+        Assert.Equal((MuhenkanVk, false), result.Inject[0]); // 無変換↓
+        Assert.Equal((MuhenkanVk, true),  result.Inject[1]); // 無変換↑
+    }
+
+    [Fact]
+    public void チャード_WaitingForSequence中の未登録キーはリーダーチャード元キーを再注入する()
+    {
+        using var tracker = CreateChordTracker();
+        HotkeyEntry? fired = null;
+        tracker.SequenceMatched += e => fired = e;
+
+        tracker.OnKeyDown(MuhenkanVk);
+        tracker.OnKeyDown(SpaceVk);
+        var result = tracker.OnKeyDown(AVk); // 未登録キー
+
+        Assert.Null(fired);
+        Assert.True(result.Block);
+        Assert.Equal(3, result.Inject.Count);
+        Assert.Equal((MuhenkanVk, false), result.Inject[0]);
+        Assert.Equal((SpaceVk,    false), result.Inject[1]);
+        Assert.Equal((AVk,        false), result.Inject[2]);
     }
 }

--- a/src/Hotlaunch.Tests/ModifierRemapperTests.cs
+++ b/src/Hotlaunch.Tests/ModifierRemapperTests.cs
@@ -15,11 +15,11 @@ public class ModifierRemapperTests
         => new ModifierRemapper([(MuhenkanVk, CtrlVk)]);
 
     [Fact]
-    public void ソースキー押下はブロックされ何も注入しない()
+    public void ソースキー押下は素通しで何も注入しない()
     {
         var r = Create();
         var result = r.OnKeyDown(MuhenkanVk);
-        Assert.True(result.Block);
+        Assert.False(result.Block); // 物理キーを素通し（親指シフト等がそのまま受け取れる）
         Assert.Empty(result.Inject);
     }
 
@@ -50,7 +50,7 @@ public class ModifierRemapperTests
     }
 
     [Fact]
-    public void ソースキーリリースでターゲットキーアップが注入される()
+    public void ソースキーリリースでターゲットキーアップが注入され物理キーは素通し()
     {
         var r = Create();
         r.OnKeyDown(MuhenkanVk);
@@ -58,22 +58,21 @@ public class ModifierRemapperTests
         r.OnKeyUp(CVk);
         var result = r.OnKeyUp(MuhenkanVk);
 
-        Assert.True(result.Block);
+        Assert.False(result.Block); // 物理↑も素通し
         Assert.Single(result.Inject);
         Assert.Equal((CtrlVk, true), result.Inject[0]);
     }
 
     [Fact]
-    public void 単独押しリリースでは元キーを注入する()
+    public void 単独押しリリースは素通しで注入しない()
     {
+        // OnKeyDown で物理↓が素通し済みなので OnKeyUp も素通し（注入不要）
         var r = Create();
         r.OnKeyDown(MuhenkanVk);
         var result = r.OnKeyUp(MuhenkanVk);
 
-        Assert.True(result.Block);
-        Assert.Equal(2, result.Inject.Count);
-        Assert.Equal((MuhenkanVk, false), result.Inject[0]); // 元キー↓
-        Assert.Equal((MuhenkanVk, true),  result.Inject[1]); // 元キー↑
+        Assert.False(result.Block);
+        Assert.Empty(result.Inject);
     }
 
     [Fact]

--- a/src/Hotlaunch/HotlaunchFactory.cs
+++ b/src/Hotlaunch/HotlaunchFactory.cs
@@ -35,6 +35,7 @@ static class HotlaunchFactory
         ["F1"]  = 0x70, ["F2"]  = 0x71, ["F3"]  = 0x72, ["F4"]  = 0x73,
         ["F5"]  = 0x74, ["F6"]  = 0x75, ["F7"]  = 0x76, ["F8"]  = 0x77,
         ["F9"]  = 0x78, ["F10"] = 0x79, ["F11"] = 0x7A, ["F12"] = 0x7B,
+        ["F13"] = 0x7C, ["F14"] = 0x7D, ["F15"] = 0x7E, ["F16"] = 0x7F,
         // 特殊キー
         ["Return"]   = 0x0D, ["Enter"]    = 0x0D,
         ["Space"]    = 0x20, ["Tab"]      = 0x09,
@@ -61,7 +62,7 @@ static class HotlaunchFactory
         int leaderVk = ParseVk(config.Leader.Key);
         int chordVk  = config.Leader.ChordKey != null ? ParseVk(config.Leader.ChordKey) : -1;
         var sequences = config.Hotkeys.Select(h => (ParseVk(h.Key), h));
-        var tracker = new LeaderSequenceTracker(leaderVk, config.Leader.TimeoutMs, sequences, config.Leader.Count, chordVk);
+        var tracker = new LeaderSequenceTracker(leaderVk, config.Leader.TimeoutMs, sequences, config.Leader.Count, chordVk, config.Leader.ChordDelayMs);
 
         tracker.SequenceMatched += entry => launcher.Launch(entry);
 

--- a/src/Hotlaunch/HotlaunchFactory.cs
+++ b/src/Hotlaunch/HotlaunchFactory.cs
@@ -59,8 +59,9 @@ static class HotlaunchFactory
         var launcher = new AppLauncher(new Win32ProcessFinder(), new Win32WindowFocuser(), new Win32ProcessStarter());
 
         int leaderVk = ParseVk(config.Leader.Key);
+        int chordVk  = config.Leader.ChordKey != null ? ParseVk(config.Leader.ChordKey) : -1;
         var sequences = config.Hotkeys.Select(h => (ParseVk(h.Key), h));
-        var tracker = new LeaderSequenceTracker(leaderVk, config.Leader.TimeoutMs, sequences, config.Leader.Count);
+        var tracker = new LeaderSequenceTracker(leaderVk, config.Leader.TimeoutMs, sequences, config.Leader.Count, chordVk);
 
         tracker.SequenceMatched += entry => launcher.Launch(entry);
 

--- a/src/Hotlaunch/KeyboardHook.cs
+++ b/src/Hotlaunch/KeyboardHook.cs
@@ -179,7 +179,9 @@ sealed class KeyboardHook : IDisposable
             var trackerResult = _tracker.OnKeyDown(vk);
             if (trackerResult.Block)
             {
-                _remapper?.SuppressNextKeyUp(vk);
+                // リマッパーソースキー（無変換等）のみ ghost 抑制。Ctrl 等の通常キーは不要。
+                if (_remapper?.IsSourceKey(vk) == true)
+                    _remapper.SuppressNextKeyUp(vk);
                 if (trackerResult.InjectForRemapper.Count > 0) DispatchInjectForRemapper(trackerResult.InjectForRemapper);
                 if (trackerResult.Inject.Count > 0) SendKeys(trackerResult.Inject);
                 return (IntPtr)1;
@@ -194,7 +196,16 @@ sealed class KeyboardHook : IDisposable
             var trackerResult = _tracker.OnKeyDown(vk);
             if (trackerResult.Block)
             {
-                _remapper?.SuppressNextKeyUp(vk);
+                if (trackerResult.Inject.Count > 0)
+                {
+                    // 同時押しキャンセル: 素通し再注入（Space↑は抑制しない）
+                    SendKeys(trackerResult.Inject);
+                }
+                else
+                {
+                    // 通常チャード起動: チャードキーの↑を抑制
+                    _remapper?.SuppressNextKeyUp(vk);
+                }
                 return (IntPtr)1;
             }
         }
@@ -202,9 +213,16 @@ sealed class KeyboardHook : IDisposable
         // [2c] キーアップ: チャードモードでリーダー修飾キー解放時の状態更新（リマッパーより前に実行）
         if (!isRemapOnly && isUp && _tracker.ChordVk >= 0)
         {
-            var upResult = _tracker.OnKeyUp(vk);
-            if (upResult.Inject.Count > 0) SendKeys(upResult.Inject); // ソロタップ再注入
-            if (upResult.Block) return (IntPtr)1;
+            bool wasHolding = _tracker.IsHoldingModifier;
+            bool leaderReleased = _tracker.OnKeyUp(vk);
+
+            if (leaderReleased && _remapper?.IsSourceKey(vk) == true)
+            {
+                // IMEキー（無変換等）のソロタップ: 再注入して物理↑をブロック
+                SendKeys([(vk, false), (vk, true)]);
+                return (IntPtr)1;
+            }
+            // 通常キー（Ctrl等）: 物理↑をそのまま通す → 以降の処理へ
         }
 
         // [3] リマッパー処理（物理キーと REMAP_ONLY 注入の両方）

--- a/src/Hotlaunch/KeyboardHook.cs
+++ b/src/Hotlaunch/KeyboardHook.cs
@@ -78,6 +78,8 @@ sealed class KeyboardHook : IDisposable
     private const int WM_SYSKEYUP     = 0x0105;
     private const uint WM_QUIT        = 0x0012;
     private const uint LLKHF_INJECTED = 0x10;
+    // リマッパーだけ通過させる注入イベントのマーカー（dwExtraInfo に設定）
+    private static readonly IntPtr HOTLAUNCH_REMAP_MARKER = new(0x484C4A01);
 
     private readonly LowLevelKeyboardProc _proc; // GC されないよう保持
     private readonly LeaderSequenceTracker _tracker;
@@ -149,8 +151,63 @@ sealed class KeyboardHook : IDisposable
         Log.Debug("フック受信: VK=0x{VkHex} isDown={IsDown} isUp={IsUp} isInjected={IsInjected}",
             vk.ToString("X2"), isDown, isUp, isInjected);
 
-        if (isInjected) return CallNextHookEx(_hookId, nCode, wParam, lParam);
+        // REMAP_ONLY 注入: リマッパーのみ通過（PressingLeader キャンセル時のリーダー+コンボキー再注入）
+        bool isRemapOnly = isInjected && kbs.dwExtraInfo == HOTLAUNCH_REMAP_MARKER;
+        // その他のすべての注入イベント（hotlaunch 自身の通常注入・外部アプリの注入）はスキップ
+        if (isInjected && !isRemapOnly) return CallNextHookEx(_hookId, nCode, wParam, lParam);
 
+        // [1] シーケンス待機中はシーケンスキーをリマッパーより優先
+        bool trackerEarlyHandled = false;
+        if (!isRemapOnly && isDown && _tracker.IsWaitingForSequence && _tracker.IsSequenceKey(vk))
+        {
+            Log.Debug("トラッカー優先: WaitingForSequence + シーケンスキー 0x{VkHex}", vk.ToString("X2"));
+            var trackerResult = _tracker.OnKeyDown(vk);
+            if (trackerResult.Inject.Count > 0) SendKeys(trackerResult.Inject);
+            if (trackerResult.Block)
+            {
+                _remapper?.Reset();
+                return (IntPtr)1;
+            }
+            trackerEarlyHandled = true;
+        }
+
+        // [2] リーダーキーはトラッカーを優先（リマッパーがソースキーとして横取りする前に処理）
+        bool leaderHandled = false;
+        if (!isRemapOnly && isDown && vk == _tracker.LeaderVk)
+        {
+            Log.Debug("リーダーキー優先処理: 0x{VkHex}", vk.ToString("X2"));
+            var trackerResult = _tracker.OnKeyDown(vk);
+            if (trackerResult.Block)
+            {
+                _remapper?.SuppressNextKeyUp(vk);
+                if (trackerResult.InjectForRemapper.Count > 0) DispatchInjectForRemapper(trackerResult.InjectForRemapper);
+                if (trackerResult.Inject.Count > 0) SendKeys(trackerResult.Inject);
+                return (IntPtr)1;
+            }
+            leaderHandled = true;
+        }
+
+        // [2b] チャードキー: HoldingModifier 状態でチャードキーを検出（リマッパーより優先）
+        if (!isRemapOnly && isDown && _tracker.ChordVk >= 0 && vk == _tracker.ChordVk && _tracker.IsHoldingModifier)
+        {
+            Log.Debug("チャードキー優先処理: 0x{VkHex}", vk.ToString("X2"));
+            var trackerResult = _tracker.OnKeyDown(vk);
+            if (trackerResult.Block)
+            {
+                _remapper?.SuppressNextKeyUp(vk);
+                return (IntPtr)1;
+            }
+        }
+
+        // [2c] キーアップ: チャードモードでリーダー修飾キー解放時の状態更新（リマッパーより前に実行）
+        if (!isRemapOnly && isUp && _tracker.ChordVk >= 0)
+        {
+            var upResult = _tracker.OnKeyUp(vk);
+            if (upResult.Inject.Count > 0) SendKeys(upResult.Inject); // ソロタップ再注入
+            if (upResult.Block) return (IntPtr)1;
+        }
+
+        // [3] リマッパー処理（物理キーと REMAP_ONLY 注入の両方）
         if (_remapper != null)
         {
             var result = isDown ? _remapper.OnKeyDown(vk)
@@ -161,21 +218,46 @@ sealed class KeyboardHook : IDisposable
             if (result.Block) return (IntPtr)1;
         }
 
-        if (isDown)
+        // [4] トラッカー処理（物理キー・リーダー/シーケンス処理済みを除く）
+        if (!isRemapOnly && isDown && !trackerEarlyHandled && !leaderHandled)
         {
             Log.Debug("キー押下: VK={VkCode} (0x{VkHex})", vk, vk.ToString("X2"));
-            if (_tracker.OnKeyDown(vk))
-                return (IntPtr)1;
+            var trackerResult = _tracker.OnKeyDown(vk);
+            if (trackerResult.InjectForRemapper.Count > 0) DispatchInjectForRemapper(trackerResult.InjectForRemapper);
+            if (trackerResult.Inject.Count > 0) SendKeys(trackerResult.Inject);
+            if (trackerResult.Block) return (IntPtr)1;
         }
 
         return CallNextHookEx(_hookId, nCode, wParam, lParam);
     }
 
     private void SendKeys(IReadOnlyList<(int Vk, bool KeyUp)> keys)
+        => SendInputInternal(keys, IntPtr.Zero);
+
+    /// <summary>リマッパーだけ通過させる注入（PressingLeader キャンセル時のリーダー+コンボキー）</summary>
+    private void SendKeysForRemapper(IReadOnlyList<(int Vk, bool KeyUp)> keys)
+        => SendInputInternal(keys, HOTLAUNCH_REMAP_MARKER);
+
+    /// <summary>
+    /// InjectForRemapper を処理する。コンボ対象キーならリマッパー経由、
+    /// IMEキー等の非コンボ対象なら素通し注入（変換+無変換が Ctrl+変換 になるのを防ぐ）。
+    /// </summary>
+    private void DispatchInjectForRemapper(IReadOnlyList<(int Vk, bool KeyUp)> keys)
+    {
+        if (keys.Count == 0) return;
+        // 末尾がコンボキー（リーダー×N + コンボキー1個 の構成）
+        var comboKey = keys[^1];
+        if (_remapper?.IsComboTarget(comboKey.Vk) ?? true)
+            SendKeysForRemapper(keys);   // Ctrl+C など: リマッパー経由
+        else
+            SendKeys(keys);              // 変換など IME キー: 素通し注入
+    }
+
+    private void SendInputInternal(IReadOnlyList<(int Vk, bool KeyUp)> keys, IntPtr extraInfo)
     {
         var inputs = new INPUT[keys.Count];
         for (int i = 0; i < keys.Count; i++)
-            inputs[i] = new INPUT { Type = 1, ki = new KEYBDINPUT { wVk = (ushort)keys[i].Vk, dwFlags = keys[i].KeyUp ? 0x0002u : 0u } };
+            inputs[i] = new INPUT { Type = 1, ki = new KEYBDINPUT { wVk = (ushort)keys[i].Vk, dwFlags = keys[i].KeyUp ? 0x0002u : 0u, dwExtraInfo = extraInfo } };
         uint sent = SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<INPUT>());
         if (sent != (uint)inputs.Length)
             Log.Warning("SendInput 失敗: sent={Sent}/{Total} err={Err}", sent, inputs.Length, Marshal.GetLastWin32Error());


### PR DESCRIPTION
Closes #21


## 変更内容

### チャードリーダーモードの実装
- `LeaderConfig.ChordKey` / `ChordDelayMs` を追加（無変換+Space 等のコードリーダー設定）
- `LeaderSequenceTracker` に `HoldingModifier` 状態を追加し、状態遷移を実装
  - `HoldingModifier` 中のソロタップ → `Inject` でシステムに素通し（IME キーが効かなくなる問題を解消）
  - `HoldingModifier` 中のチャード以外のキー → `InjectForRemapper` でリマッパー経由再注入（Ctrl+C 等を維持）
  - 同時押し検出（`ChordDelayMs` 未満）→ 親指シフト等として素通し再注入
- `RemapResult` に `InjectForRemapper` フィールドを追加（後方互換の 2 引数コンストラクタあり）
- `LeaderActivated` / `LeaderDeactivated` イベントを `WaitingForSequence` との境界でのみ発火するよう修正

### ModifierRemapper の改善
- ソースキー押下を**素通し**に変更（親指シフト等がそのまま受け取れる）
- `NonComboKeys`（変換・無変換・カナ・Space）をコンボ対象外に設定
- `SuppressNextKeyUp` / `IsSourceKey` / `IsComboTarget` を追加
- `Reset()` 時にゴーストソース抑制（誤ったソロタップ注入を防ぐ）

### KeyboardHook の改善
- `HOTLAUNCH_REMAP_MARKER`（`dwExtraInfo`）を使ったリマッパー専用注入の実装
- リーダーキーをリマッパーより先に処理するセクション `[2]` を追加（無変換のリマッパー横取り問題を解消）
- チャードキーの優先処理セクション `[2b]`、キーアップ処理 `[2c]` を追加
- `DispatchInjectForRemapper`：IME キーは素通し、通常キーはリマッパー経由に振り分け

### その他
- F13〜F16 キー対応を追加
- `publish/` を `.gitignore` に追加
- `CLAUDE.md` にアーキテクチャ注意点（状態遷移・NonComboKeys・リーダー競合）を追記

## テスト方法

```bash
cd src
dotnet test Hotlaunch.Tests/Hotlaunch.Tests.csproj
```

- `LeaderSequenceTrackerTests`: チャードリーダーモードのテスト追加・既存テストを `RemapResult` 対応に更新
- `ModifierRemapperTests`: ソースキー素通し・単独押し素通しの挙動変更に合わせてテスト更新

### 動作確認（手動）

`appsettings.json` で `ChordKey: "Space"` を設定し、無変換+Space → W の順で押下してシーケンスが発火することを確認。また無変換単独タップで IME 切り替えが正常に機能することを確認。