### PR TITLE
無変換→Ctrl変換の実装

### DIFF
--- a/src/Hotlaunch.Core/ModifierRemapper.cs
+++ b/src/Hotlaunch.Core/ModifierRemapper.cs
@@ -93,10 +93,16 @@ public sealed class ModifierRemapper
             }
         }
 
-        // ソースキー押下 → 追跡開始（物理キーは素通し: 親指シフト等がそのまま受け取れる）
-        if (_rules.ContainsKey(vkCode))
+        // ソースキー押下 → 追跡開始
+        // SoloKey が設定されている場合は DOWN も抑制（さもないと UP を抑制した際に OS 側で押しっぱなしになる）
+        if (_rules.TryGetValue(vkCode, out var sourceRule))
         {
             _heldSources.Add(vkCode);
+            if (sourceRule.SoloVk.HasValue)
+            {
+                Log.Information("リマッパー: 0x{VkHex} 押下 → ソースキー追跡開始 (抑制)", vkCode.ToString("X2"));
+                return new RemapResult(true, []);
+            }
             Log.Information("リマッパー: 0x{VkHex} 押下 → ソースキー追跡開始 (素通し)", vkCode.ToString("X2"));
             return new RemapResult(false, []);
         }


### PR DESCRIPTION
Closes #26


## 変更内容

`SoloKey`（単独押し時の別キー）が設定されているソースキーに対して、DOWN イベントも抑制するよう修正した。

**修正前の問題:**
- ソースキーの DOWN は素通し（OS に送信）
- UP のみ抑制していたため、OS 側でキーが押しっぱなし状態になる不具合があった

**修正後:**
- `SoloVk` が設定されているルールでは DOWN も抑制 (`return new RemapResult(true, [])`)
- `SoloVk` がないルールは従来通り素通し（親指シフト等との互換性維持）

```csharp
if (sourceRule.SoloVk.HasValue)
{
    // DOWN を抑制してキー押しっぱなし防止
    return new RemapResult(true, []);
}
// SoloVk なし → 素通し
return new RemapResult(false, []);
```

## テスト方法

1. 無変換キーを単独押しして離す → `SoloVk` に設定したキー（例: Ctrl）が一発だけ発火し、押しっぱなしにならないことを確認
2. 無変換キーを他のキーとコンボ（無変換＋A など）で押す → Ctrl コンボとして機能することを確認
3. `SoloVk` を持たないリマップルールで、ソースキーが従来通り素通しになることを確認