### PR TITLE
設定スキーマv1マイグレーション追加

### DIFF
--- a/src/Hotlaunch.Core/Config/ConfigManager.cs
+++ b/src/Hotlaunch.Core/Config/ConfigManager.cs
@@ -1,9 +1,12 @@
 using System.Text.Json;
+using Serilog;
 
 namespace Hotlaunch.Core.Config;
 
 public class ConfigManager(string configPath) : IConfigManager
 {
+    private const int CurrentSchemaVersion = 1;
+
     private static readonly JsonSerializerOptions Options = new()
     {
         PropertyNameCaseInsensitive = true,
@@ -19,15 +22,24 @@ public class ConfigManager(string configPath) : IConfigManager
         if (!File.Exists(configPath))
             return CreateDefault();
 
+        AppConfig config;
         try
         {
             var json = File.ReadAllText(configPath);
-            return JsonSerializer.Deserialize<AppConfig>(json, Options) ?? CreateDefault();
+            config = JsonSerializer.Deserialize<AppConfig>(json, Options) ?? CreateDefault();
         }
         catch
         {
             return CreateDefault();
         }
+
+        if (config.SchemaVersion < CurrentSchemaVersion)
+        {
+            config = Migrate(config);
+            Save(config);
+        }
+
+        return config;
     }
 
     public void Save(AppConfig config)
@@ -36,10 +48,33 @@ public class ConfigManager(string configPath) : IConfigManager
         File.WriteAllText(configPath, JsonSerializer.Serialize(config, Options));
     }
 
+    private static AppConfig Migrate(AppConfig config)
+    {
+        int from = config.SchemaVersion;
+
+        // v0 → v1: LCtrl リマップがなければ追加
+        if (config.SchemaVersion < 1)
+        {
+            if (config.ModifierRemaps.Length == 0)
+            {
+                config.ModifierRemaps =
+                [
+                    new ModifierRemapConfig { Source = "LCtrl", Target = "LCtrl", SoloKey = "Muhenkan" },
+                ];
+                Log.Information("設定マイグレーション v0→v1: LCtrl リマップを追加しました");
+            }
+            config.SchemaVersion = 1;
+        }
+
+        Log.Information("設定マイグレーション完了: v{From} → v{To}", from, config.SchemaVersion);
+        return config;
+    }
+
     private AppConfig CreateDefault()
     {
         var config = new AppConfig
         {
+            SchemaVersion = CurrentSchemaVersion,
             Leader = new LeaderConfig { Key = "F12", TimeoutMs = 2000, Count = 1 },
             ModifierRemaps =
             [

--- a/src/Hotlaunch.Core/Config/HotkeyConfig.cs
+++ b/src/Hotlaunch.Core/Config/HotkeyConfig.cs
@@ -27,6 +27,7 @@ public class ModifierRemapConfig
 
 public class AppConfig
 {
+    public int SchemaVersion { get; set; } = 0;
     public LeaderConfig Leader { get; set; } = new();
     public ModifierRemapConfig[] ModifierRemaps { get; set; } = [];
     public HotkeyEntry[] Hotkeys { get; set; } = [];

--- a/src/Hotlaunch.Tests/ConfigManagerTests.cs
+++ b/src/Hotlaunch.Tests/ConfigManagerTests.cs
@@ -67,6 +67,54 @@ public class ConfigManagerTests : IDisposable
         Assert.Equal("F12", config.Leader.Key);
     }
 
+    [Fact]
+    public void v0設定にModifierRemapsがない場合マイグレーションでLCtrlが追加される()
+    {
+        var path = Path.Combine(_tempDir, "config.json");
+        Directory.CreateDirectory(_tempDir);
+        // SchemaVersion なし・ModifierRemaps なしの旧設定
+        File.WriteAllText(path, """{"Leader":{"Key":"F12","TimeoutMs":2000,"Count":1},"Hotkeys":[],"DirectHotkeys":[]}""");
+
+        var manager = new ConfigManager(path);
+        var config = manager.Load();
+
+        Assert.Equal(1, config.SchemaVersion);
+        Assert.Single(config.ModifierRemaps);
+        Assert.Equal("LCtrl", config.ModifierRemaps[0].Source);
+        Assert.Equal("Muhenkan", config.ModifierRemaps[0].SoloKey);
+    }
+
+    [Fact]
+    public void v0設定にModifierRemapsがある場合マイグレーションで上書きしない()
+    {
+        var path = Path.Combine(_tempDir, "config.json");
+        Directory.CreateDirectory(_tempDir);
+        // すでにカスタムのリマップが存在する旧設定
+        File.WriteAllText(path, """{"Leader":{"Key":"F12","TimeoutMs":2000,"Count":1},"ModifierRemaps":[{"Source":"Muhenkan","Target":"Ctrl","SoloKey":null}],"Hotkeys":[],"DirectHotkeys":[]}""");
+
+        var manager = new ConfigManager(path);
+        var config = manager.Load();
+
+        Assert.Equal(1, config.SchemaVersion);
+        Assert.Single(config.ModifierRemaps);
+        Assert.Equal("Muhenkan", config.ModifierRemaps[0].Source); // 既存設定を保持
+    }
+
+    [Fact]
+    public void マイグレーション後にファイルが更新される()
+    {
+        var path = Path.Combine(_tempDir, "config.json");
+        Directory.CreateDirectory(_tempDir);
+        File.WriteAllText(path, """{"Leader":{"Key":"F12","TimeoutMs":2000,"Count":1},"Hotkeys":[],"DirectHotkeys":[]}""");
+
+        var manager = new ConfigManager(path);
+        manager.Load();
+
+        var savedJson = File.ReadAllText(path);
+        Assert.Contains("\"SchemaVersion\": 1", savedJson);
+        Assert.Contains("LCtrl", savedJson);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDir))

--- a/src/Hotlaunch/TrayApp.cs
+++ b/src/Hotlaunch/TrayApp.cs
@@ -24,6 +24,10 @@ sealed class TrayApp : IDisposable
     public TrayApp()
     {
         var config = ConfigManager.Default.Load();
+        Log.Information("設定読み込み: ModifierRemaps={RemapCount}, Hotkeys={HotkeyCount}, DirectHotkeys={DirectCount}",
+            config.ModifierRemaps.Length, config.Hotkeys.Length, config.DirectHotkeys.Length);
+        foreach (var remap in config.ModifierRemaps)
+            Log.Information("  リマップ: {Source} → {Target} (SoloKey={SoloKey})", remap.Source, remap.Target, remap.SoloKey ?? "なし");
         (_tracker, _, _hook) = HotlaunchFactory.Create(config);
 
         var contextMenu = new ContextMenu();


### PR DESCRIPTION
Closes #31


## 変更内容

- `AppConfig` に `SchemaVersion` フィールドを追加（デフォルト 0）
- `ConfigManager` にスキーマバージョン管理とマイグレーション処理を実装
  - v0→v1: `ModifierRemaps` が空の旧設定に `LCtrl→Muhenkan` リマップを自動追加
  - 既存のリマップ設定がある場合は上書きしない
  - マイグレーション後に設定ファイルを自動保存
- `TrayApp` 起動時に読み込んだ設定内容（リマップ数・ホットキー数・各リマップ詳細）をログ出力

## テスト方法

- `dotnet test` で以下のテストケースが通ることを確認
  - `v0設定にModifierRemapsがない場合マイグレーションでLCtrlが追加される`
  - `v0設定にModifierRemapsがある場合マイグレーションで上書きしない`
  - `マイグレーション後にファイルが更新される`
- `SchemaVersion` なしの旧設定ファイルを用意して hotlaunch を起動し、ファイルに `"SchemaVersion": 1` と `LCtrl` リマップが書き込まれることを確認