### PR TITLE
マイグレーションをデフォルトマージに置換

### DIFF
--- a/src/Hotlaunch.Core/Config/ConfigManager.cs
+++ b/src/Hotlaunch.Core/Config/ConfigManager.cs
@@ -5,7 +5,11 @@ namespace Hotlaunch.Core.Config;
 
 public class ConfigManager(string configPath) : IConfigManager
 {
-    private const int CurrentSchemaVersion = 1;
+    // 毎起動時にこのリストと比較し、Source が存在しないエントリを自動追加する
+    private static readonly ModifierRemapConfig[] DefaultModifierRemaps =
+    [
+        new ModifierRemapConfig { Source = "LCtrl", Target = "LCtrl", SoloKey = "Muhenkan" },
+    ];
 
     private static readonly JsonSerializerOptions Options = new()
     {
@@ -33,11 +37,8 @@ public class ConfigManager(string configPath) : IConfigManager
             return CreateDefault();
         }
 
-        if (config.SchemaVersion < CurrentSchemaVersion)
-        {
-            config = Migrate(config);
+        if (MergeMissingDefaults(config))
             Save(config);
-        }
 
         return config;
     }
@@ -48,38 +49,27 @@ public class ConfigManager(string configPath) : IConfigManager
         File.WriteAllText(configPath, JsonSerializer.Serialize(config, Options));
     }
 
-    private static AppConfig Migrate(AppConfig config)
+    private static bool MergeMissingDefaults(AppConfig config)
     {
-        int from = config.SchemaVersion;
-
-        // v0 → v1: LCtrl リマップがなければ追加
-        if (config.SchemaVersion < 1)
+        bool changed = false;
+        foreach (var def in DefaultModifierRemaps)
         {
-            if (config.ModifierRemaps.Length == 0)
-            {
-                config.ModifierRemaps =
-                [
-                    new ModifierRemapConfig { Source = "LCtrl", Target = "LCtrl", SoloKey = "Muhenkan" },
-                ];
-                Log.Information("設定マイグレーション v0→v1: LCtrl リマップを追加しました");
-            }
-            config.SchemaVersion = 1;
+            if (config.ModifierRemaps.Any(r => string.Equals(r.Source, def.Source, StringComparison.OrdinalIgnoreCase)))
+                continue;
+            config.ModifierRemaps = [..config.ModifierRemaps, def];
+            Log.Information("設定: デフォルトのリマップを追加しました: {Source} → {Target} (SoloKey={SoloKey})",
+                def.Source, def.Target, def.SoloKey ?? "なし");
+            changed = true;
         }
-
-        Log.Information("設定マイグレーション完了: v{From} → v{To}", from, config.SchemaVersion);
-        return config;
+        return changed;
     }
 
     private AppConfig CreateDefault()
     {
         var config = new AppConfig
         {
-            SchemaVersion = CurrentSchemaVersion,
             Leader = new LeaderConfig { Key = "F12", TimeoutMs = 2000, Count = 1 },
-            ModifierRemaps =
-            [
-                new ModifierRemapConfig { Source = "LCtrl", Target = "LCtrl", SoloKey = "Muhenkan" },
-            ],
+            ModifierRemaps = DefaultModifierRemaps.ToArray(),
             Hotkeys =
             [
                 new HotkeyEntry

--- a/src/Hotlaunch.Core/Config/HotkeyConfig.cs
+++ b/src/Hotlaunch.Core/Config/HotkeyConfig.cs
@@ -27,7 +27,6 @@ public class ModifierRemapConfig
 
 public class AppConfig
 {
-    public int SchemaVersion { get; set; } = 0;
     public LeaderConfig Leader { get; set; } = new();
     public ModifierRemapConfig[] ModifierRemaps { get; set; } = [];
     public HotkeyEntry[] Hotkeys { get; set; } = [];

--- a/src/Hotlaunch.Tests/ConfigManagerTests.cs
+++ b/src/Hotlaunch.Tests/ConfigManagerTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Hotlaunch.Core.Config;
 using Xunit;
 
@@ -36,6 +35,7 @@ public class ConfigManagerTests : IDisposable
         var original = new AppConfig
         {
             Leader = new LeaderConfig { Key = "Alt", TimeoutMs = 1500 },
+            ModifierRemaps = [new ModifierRemapConfig { Source = "LCtrl", Target = "LCtrl", SoloKey = "Muhenkan" }],
             Hotkeys =
             [
                 new HotkeyEntry { Key = "T", AppPath = @"C:\term.exe", ProcessName = "term", Args = "--here" },
@@ -68,50 +68,61 @@ public class ConfigManagerTests : IDisposable
     }
 
     [Fact]
-    public void v0設定にModifierRemapsがない場合マイグレーションでLCtrlが追加される()
+    public void ModifierRemapsにLCtrlがない場合起動時に自動追加される()
     {
         var path = Path.Combine(_tempDir, "config.json");
         Directory.CreateDirectory(_tempDir);
-        // SchemaVersion なし・ModifierRemaps なしの旧設定
-        File.WriteAllText(path, """{"Leader":{"Key":"F12","TimeoutMs":2000,"Count":1},"Hotkeys":[],"DirectHotkeys":[]}""");
+        // LCtrl なしの既存設定
+        File.WriteAllText(path, """{"Leader":{"Key":"F12","TimeoutMs":2000,"Count":1},"ModifierRemaps":[],"Hotkeys":[],"DirectHotkeys":[]}""");
 
         var manager = new ConfigManager(path);
         var config = manager.Load();
 
-        Assert.Equal(1, config.SchemaVersion);
         Assert.Single(config.ModifierRemaps);
         Assert.Equal("LCtrl", config.ModifierRemaps[0].Source);
         Assert.Equal("Muhenkan", config.ModifierRemaps[0].SoloKey);
     }
 
     [Fact]
-    public void v0設定にModifierRemapsがある場合マイグレーションで上書きしない()
+    public void ModifierRemapsにMuhenkanだけある場合LCtrlが追加される()
     {
         var path = Path.Combine(_tempDir, "config.json");
         Directory.CreateDirectory(_tempDir);
-        // すでにカスタムのリマップが存在する旧設定
+        // 別のPCのケース: Muhenkan→Ctrl はあるが LCtrl がない
         File.WriteAllText(path, """{"Leader":{"Key":"F12","TimeoutMs":2000,"Count":1},"ModifierRemaps":[{"Source":"Muhenkan","Target":"Ctrl","SoloKey":null}],"Hotkeys":[],"DirectHotkeys":[]}""");
 
         var manager = new ConfigManager(path);
         var config = manager.Load();
 
-        Assert.Equal(1, config.SchemaVersion);
-        Assert.Single(config.ModifierRemaps);
-        Assert.Equal("Muhenkan", config.ModifierRemaps[0].Source); // 既存設定を保持
+        Assert.Equal(2, config.ModifierRemaps.Length);
+        Assert.Contains(config.ModifierRemaps, r => r.Source == "Muhenkan"); // 既存設定を保持
+        Assert.Contains(config.ModifierRemaps, r => r.Source == "LCtrl");   // デフォルトを追加
     }
 
     [Fact]
-    public void マイグレーション後にファイルが更新される()
+    public void ModifierRemapsにLCtrlが既にある場合重複追加しない()
     {
         var path = Path.Combine(_tempDir, "config.json");
         Directory.CreateDirectory(_tempDir);
-        File.WriteAllText(path, """{"Leader":{"Key":"F12","TimeoutMs":2000,"Count":1},"Hotkeys":[],"DirectHotkeys":[]}""");
+        File.WriteAllText(path, """{"Leader":{"Key":"F12","TimeoutMs":2000,"Count":1},"ModifierRemaps":[{"Source":"LCtrl","Target":"LCtrl","SoloKey":"Muhenkan"}],"Hotkeys":[],"DirectHotkeys":[]}""");
+
+        var manager = new ConfigManager(path);
+        var config = manager.Load();
+
+        Assert.Single(config.ModifierRemaps); // 重複しない
+    }
+
+    [Fact]
+    public void 不足エントリ追加後にファイルが保存される()
+    {
+        var path = Path.Combine(_tempDir, "config.json");
+        Directory.CreateDirectory(_tempDir);
+        File.WriteAllText(path, """{"Leader":{"Key":"F12","TimeoutMs":2000,"Count":1},"ModifierRemaps":[],"Hotkeys":[],"DirectHotkeys":[]}""");
 
         var manager = new ConfigManager(path);
         manager.Load();
 
         var savedJson = File.ReadAllText(path);
-        Assert.Contains("\"SchemaVersion\": 1", savedJson);
         Assert.Contains("LCtrl", savedJson);
     }
 


### PR DESCRIPTION
Closes #33


## 変更内容

- `AppConfig.SchemaVersion` フィールドを削除
- スキーマバージョンベースの `Migrate()` メソッドを廃止し、`MergeMissingDefaults()` に置換
- 起動のたびに `DefaultModifierRemaps` と比較し、`Source` が存在しないエントリを自動追加する仕組みに変更
- テストを新しい挙動に合わせて更新（既存LCtrlがある場合の重複追加テストを追加）

## テスト方法

- [ ] LCtrl リマップなしの既存設定ファイルで起動 → LCtrl が自動追加されることを確認
- [ ] LCtrl リマップ済みの設定ファイルで起動 → 重複追加されないことを確認
- [ ] `dotnet test` で全テストが通ることを確認